### PR TITLE
Show analysis recommended by tagger for black node

### DIFF
--- a/tred-extension/pdt_c_m/stylesheets/PML_M_36_SC
+++ b/tred-extension/pdt_c_m/stylesheets/PML_M_36_SC
@@ -20,7 +20,9 @@ node:<? $${#name} eq "s" ? '#{gray}${id}' :
 node: <?
     if (1 < @{ [ AltV($this->attr('tag')) ] } ) {
         my ($sel) = grep $_->get_attribute('selected'), AltV($this->attr('tag'));
-        $sel ? $sel->get_attribute('lemma') . "\n" . $sel->value : ''
+        my ($recom) = grep $_->get_attribute('recommended'), AltV($this->attr('tag'));
+        $sel ? $sel->get_attribute('lemma') . "\n" . $sel->value :
+           '#{darkgray}' . $recom->get_attribute('lemma') . "\n" . $recom->value
     } elsif ($this->attr('tag')->value !~ /^X@-+[-01]$/) {
         '#{gray}' . $this->attr('tag/lemma') . "\n" . $this->attr('tag')->value;
     }


### PR DESCRIPTION
This feature is requested by (at least one) annotator arguing that some error types can be spotted quite easily from this view and the annotation would be faster and smoother.
(Please, ping MM when new extension is published.)